### PR TITLE
fix: use require function passed into wrapper

### DIFF
--- a/lib/platform/require.js
+++ b/lib/platform/require.js
@@ -85,7 +85,7 @@ Module.patch = function (globalCtx, url, port) {
 	global._globalCtx = globalCtx;
 	Module._url = url || defaultURL;
 	Module._port = parseInt(port, 10) || 8324;
-	Module._requireNative = globalCtx.require;
+	Module._requireNative = require;
 	Module.evtServer && Module.evtServer.close();
 	Module._compileList = [];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "liveview",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liveview",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Titanium Live Realtime App Development",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Pulling from global isn't entirely correct as it will be lacking the correct context that helps
perform the require algorithm, by using the require function passed in by the wrapper that context
will exist allowing the require algorithm to work correctly

Fixes TIMOB-28382